### PR TITLE
little scan regex parsing update

### DIFF
--- a/Hooks/scans/parser.py
+++ b/Hooks/scans/parser.py
@@ -35,6 +35,7 @@ from Core.loadable import system
 from Core.robocop import push
 
 scanre=re.compile("http://[^/]+/showscan.pl\?scan_id=([0-9a-zA-Z]+)")
+scanre2=re.compile("http://[^/]+/waves.pl\?scan_id=([0-9a-zA-Z]+)")
 scangrpre=re.compile("http://[^/]+/showscan.pl\?scan_grp=([0-9a-zA-Z]+)")
 
 @system('PRIVMSG')
@@ -45,6 +46,8 @@ def catcher(message):
     except PNickParseError:
         uid = None
     for m in scanre.finditer(message.get_msg()):
+        parse(uid, "scan", m.group(1)).start()
+    for m in scanre2.finditer(message.get_msg()):
         parse(uid, "scan", m.group(1)).start()
     for m in scangrpre.finditer(message.get_msg()):
         parse(uid, "group", m.group(1)).start()


### PR DESCRIPTION
When filling requests from the website by pasting to the bot, the bot doesn't accept the scan is done if the pasted link is the one given by the scan request page,
this is ignored http://game.planetarion.com/waves.pl?scan_id=rra5htuuapfohne&x=11&y=9&z=3
but this is ok http://game.planetarion.com/showscan.pl?scan_id=rra5htuuapfohne
I added extra regex to deal with the other type so both are ok to be parsed by the bot

Added regex parsing for links pasted straight from the waves page rather than opening the individual scan link and pasting that.
