### PR TITLE
Escape <> in rulername

### DIFF
--- a/Arthur/templates/exiles.tpl
+++ b/Arthur/templates/exiles.tpl
@@ -63,7 +63,7 @@
         {%endif%}
         </td>
         
-        <td>{{ planet.rulername }}</td>
+        <td>{{ planet.rulername|e }}</td>
         <td>{{ planet.planetname }}</td>
         <td class="{{ planet.race }}">{{ planet.race }}</td>
         {%if not planet.active %}

--- a/Arthur/templates/headerbar.tpl
+++ b/Arthur/templates/headerbar.tpl
@@ -16,7 +16,7 @@
     <tr>
         <td align="center" colspan="3">
         <form method="post">
-        You are: <a class="myplanet" {{planetlink(planet)}}>{{ planet.rulername }}</a>
+        You are: <a class="myplanet" {{planetlink(planet)}}>{{ planet.rulername|e }}</a>
             (<a {{galaxyscanslink(planet.galaxy)}}>{{ planet.x }}:{{ planet.y }}</a>
             <a {{planetlink(planet)}}>{{ planet.z }}</a>)
             <span class="{{ planet.race }}">{{ planet.race }}</span>

--- a/Arthur/templates/history.tpl
+++ b/Arthur/templates/history.tpl
@@ -183,7 +183,7 @@
             &nbsp;{{ ph.z }}
         </td>
         <td><a class="gray" {{planetlink(ph)}}>
-                {{ ph.rulername }}
+                {{ ph.rulername|e }}
         </a></td>
         <td><a class="gray" {{planetlink(ph)}}>
                 {{ ph.planetname }}

--- a/Arthur/templates/hplanet.tpl
+++ b/Arthur/templates/hplanet.tpl
@@ -3,7 +3,7 @@
 {% extends "base.tpl" %}
 {% block content %}
 {% call hplanet(planet, history) %}
-    <a class="{%if planet == user.planet %}myplanet{%else%}gray{%endif%}" {{planetlink(planet)}}>{{planet.rulername}}</a>
+    <a class="{%if planet == user.planet %}myplanet{%else%}gray{%endif%}" {{planetlink(planet)}}>{{planet.rulername|e}}</a>
         <i>of</i>
     <a class="{%if planet == user.planet %}myplanet{%else%}gray{%endif%}" {{planetlink(planet)}}>{{planet.planetname}}</a>
     (<a {{galaxyscanslink(planet.galaxy)}}>{{ planet.x }}:{{ planet.y }}</a>

--- a/Arthur/templates/hsplanet.tpl
+++ b/Arthur/templates/hsplanet.tpl
@@ -3,7 +3,7 @@
 {% extends "base.tpl" %}
 {% block content %}
 {% call hsplanet(planet, hsummary) %}
-    <a class="{%if planet == user.planet %}myplanet{%else%}gray{%endif%}" {{planetlink(planet)}}>{{planet.rulername}}</a>
+    <a class="{%if planet == user.planet %}myplanet{%else%}gray{%endif%}" {{planetlink(planet)}}>{{planet.rulername|e}}</a>
         <i>of</i>
     <a class="{%if planet == user.planet %}myplanet{%else%}gray{%endif%}" {{planetlink(planet)}}>{{planet.planetname}}</a>
     (<a {{galaxyscanslink(planet.galaxy)}}>{{ planet.x }}:{{ planet.y }}</a>

--- a/Arthur/templates/planet.tpl
+++ b/Arthur/templates/planet.tpl
@@ -6,7 +6,7 @@
     <tr class="header"><th colspan="10">Planet Info</th></tr>
     <tr class="datahigh">
         <th align="center" colspan="10">
-            <a class="{%if planet == user.planet %}myplanet{%else%}gray{%endif%}" {{planetlink(planet)}}>{{planet.rulername}}</a>
+            <a class="{%if planet == user.planet %}myplanet{%else%}gray{%endif%}" {{planetlink(planet)}}>{{planet.rulername|e}}</a>
                 <i>of</i>
             <a class="{%if planet == user.planet %}myplanet{%else%}gray{%endif%}" {{planetlink(planet)}}>{{planet.planetname}}</a>
             (<a {{galaxyscanslink(planet.galaxy)}}>{{ planet.x }}:{{ planet.y }}</a>

--- a/Arthur/templates/planet_intelintitle.tpl
+++ b/Arthur/templates/planet_intelintitle.tpl
@@ -4,7 +4,7 @@
     <tr class="header"><th colspan="{{cols}}">Planet Info</th></tr>
 {% endblock %}
 {% block title %}
-    <a class="{%if planet == user.planet %}myplanet{%else%}gray{%endif%}" {{planetlink(planet)}}>{{planet.rulername}}</a>
+    <a class="{%if planet == user.planet %}myplanet{%else%}gray{%endif%}" {{planetlink(planet)}}>{{planet.rulername|e}}</a>
         <i>of</i>
     <a class="{%if planet == user.planet %}myplanet{%else%}gray{%endif%}" {{planetlink(planet)}}>{{planet.planetname}}</a>
     (<a {{galaxyscanslink(planet.galaxy)}}>{{ planet.x }}:{{ planet.y }}</a>

--- a/Arthur/templates/planets.tpl
+++ b/Arthur/templates/planets.tpl
@@ -83,7 +83,7 @@
             <a {{planetlink(planet)}}>&nbsp;{{ planet.z }}</a>
         </td>
         <td><a class="{% if planet == user.planet %}myplanet{% else %}gray{% endif %}" {{planetlink(planet)}}>
-                {{ planet.rulername }}
+                {{ planet.rulername|e }}
         </a></td>
         <td><a class="{% if planet == user.planet %}myplanet{% else %}gray{% endif %}" {{planetlink(planet)}}>
                 {{ planet.planetname }}

--- a/Arthur/templates/scans/planet_types.tpl
+++ b/Arthur/templates/scans/planet_types.tpl
@@ -1,7 +1,7 @@
 {% from 'macros.tpl' import planetscanslink, galaxyscanslink with context %}
 {% extends "scans/group.tpl" %}
 {% block title %}
-    <a class="{%if planet == user.planet %}myplanet{%else%}gray{%endif%}" {{planetscanslink(planet)}}>{{planet.rulername}}</a>
+    <a class="{%if planet == user.planet %}myplanet{%else%}gray{%endif%}" {{planetscanslink(planet)}}>{{planet.rulername|e}}</a>
         <i>of</i>
     <a class="{%if planet == user.planet %}myplanet{%else%}gray{%endif%}" {{planetscanslink(planet)}}>{{planet.planetname}}</a>
     (<a {{galaxyscanslink(planet.galaxy)}}>{{ planet.x }}:{{ planet.y }}</a>

--- a/Arthur/templates/scans/pscan.tpl
+++ b/Arthur/templates/scans/pscan.tpl
@@ -8,7 +8,7 @@
     
     <tr class="header right">
         <td> Ruler </td>
-        <td class="center"> {{ planet.rulername }} </td>
+        <td class="center"> {{ planet.rulername|e }} </td>
         <td> Planet </td>
         <td class="center"> {{ planet.planetname }} </td>
     </tr>


### PR DESCRIPTION
Wow ... this pull stuff isn't particularly intuitive.

Anyway, here's the original pull for the escape issue.

**\* REQUEST

Since apparently <> are valid chars in the rulername [1], I escaped them. Hope I've done this right [2].

Hit me on IRC (morrow) if something's fishy or this is crap.

[1] See, for example, galaxy 4:3 ~ http://pascans.zapto.org/4.3/
[2] Fixed ~ http://ultores.cheleb.net/4.3/

**\* COMMENT

This looks good, thanks. If you have time could you look at maybe a similar commit for planetname, galaxyname and maybe anything else you think relevant? (Things like intel nick don't need this as a alphanumeric limit is already in place).

On a separate note I had a look at your host and your graph cache isn't being cleared. Can you check you have this commit: https://github.com/ellonweb/merlin/commit/1c665326a304ac15e92d0ec66d6f8f5c542949e4 and also if you're running on a POSIX machine that you've +777'd /merlin/Arthur/graphs/. If that doesn't rectify the problem please raise another ticket and I'll try and find some time to get online and investigate!
